### PR TITLE
Separate checks for windows and nix systems. Windows has no logrotate.

### DIFF
--- a/file_check_nix.go
+++ b/file_check_nix.go
@@ -1,0 +1,58 @@
+// +build !windows
+
+package zapwriter
+
+import (
+	"time"
+	"fmt"
+	"syscall"
+	"os"
+)
+
+func (r *FileOutput) doWithCheck(f func()) {
+	r.Lock()
+	defer r.Unlock()
+	r.check()
+	f()
+}
+
+func (r *FileOutput) check() {
+	now := time.Now()
+
+	if now.Before(r.checkNext) {
+		return
+	}
+
+	r.checkNext = time.Now().Add(r.timeout)
+
+	fInfo, err := r.f.Stat()
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	fStat, ok := fInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		fmt.Println("Not a syscall.Stat_t")
+		return
+	}
+
+	pInfo, err := os.Stat(r.path)
+	if err != nil {
+		// file deleted (?)
+		r.reopen()
+		return
+	}
+
+	pStat, ok := pInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		fmt.Println("Not a syscall.Stat_t")
+		return
+	}
+
+	if fStat.Ino != pStat.Ino {
+		// file on disk changed
+		r.reopen()
+		return
+	}
+}

--- a/file_check_windows.go
+++ b/file_check_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package zapwriter
+
+func (r *FileOutput) doWithCheck(f func()) {
+	f()
+}


### PR DESCRIPTION
Hi! I our project https://github.com/moira-alert/moira we use carbon-api as graphite functions source. After last update from v0.9.0 to v0.10.0.1 in my dev windows mashine project compile fail because of zapwriter uses nix syscalls.